### PR TITLE
A-CodeQuality: Reduce length of method by taking away newlines

### DIFF
--- a/src/main/java/jackbit/Jackbit.java
+++ b/src/main/java/jackbit/Jackbit.java
@@ -57,7 +57,6 @@ public class Jackbit {
 
         try {
             reply = parser.parse(msg);
-
         } catch (JackbitException e) {
             try {
                 storage.save(tasks.getTaskList());
@@ -66,7 +65,6 @@ public class Jackbit {
             }
             throw new RuntimeException(e);
         }
-
 
         try {
             storage.save(tasks.getTaskList());


### PR DESCRIPTION
Unnecessary newlines increase the length of the method, so I deleted them.

No other glaring Code quality issues were found, but I may have overlooked them.